### PR TITLE
Allow header decoration in streaming mode

### DIFF
--- a/app/steps/decorateUserResHeaders.js
+++ b/app/steps/decorateUserResHeaders.js
@@ -16,7 +16,11 @@ function decorateUserResHeaders(container) {
   }
 
   return Promise
-    .resolve(resolverFn(headers, container.user.req, container.user.res, container.proxy.req, container.proxy.res))
+    .resolve(
+      resolverFn.length === 1
+        ? resolverFn(headers)
+        : resolverFn(headers, container.user.req, container.user.res, container.proxy.req, container.proxy.res)
+    )
     .then(function(headers) {
       return new Promise(function(resolve) {
         clearAllHeaders(container.user.res);

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -66,11 +66,17 @@ function resolveOptions(options) {
     timeout: options.timeout
   };
 
+
+  // allow streaming if we don't require access to the response body in userResHeaderDecorator
+
+  var userResHeaderDecoratorCanBeStreamed = !resolved.userResHeaderDecorator ||
+  resolved.userResHeaderDecorator.length === 1;
+
   // automatically opt into stream mode if no response modifiers are specified
 
   resolved.stream = !resolved.skipToNextHandlerFilter &&
                     !resolved.userResDecorator &&
-                    !resolved.userResHeaderDecorator;
+                    userResHeaderDecoratorCanBeStreamed;
 
   debug(resolved);
   return resolved;

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -69,8 +69,9 @@ function resolveOptions(options) {
 
   // allow streaming if we don't require access to the response body in userResHeaderDecorator
 
-  var userResHeaderDecoratorCanBeStreamed = !resolved.userResHeaderDecorator ||
-  resolved.userResHeaderDecorator.length === 1;
+  var userResHeaderDecoratorCanBeStreamed =
+    !resolved.userResHeaderDecorator || resolved.userResHeaderDecorator.length === 1;
+
 
   // automatically opt into stream mode if no response modifiers are specified
 

--- a/test/streaming.js
+++ b/test/streaming.js
@@ -81,7 +81,9 @@ describe('streams / piped requests', function () {
           return Object.assign({}, headers, { 'x-my-new-header': 'special-header' });
         }
       },
-      expectedHeaders: {}
+      expectedHeaders: {
+        'x-my-new-header': 'special-header'
+      }
     }];
 
     TEST_CASES.forEach(function (testCase) {


### PR DESCRIPTION
Currently, streaming mode is disabled if the `userResHeaderDecorator` response modifier is defined. However, this is overly strict and doesn't allow streaming when we only require access to the response headers, instead of the full response body.

This PR updates the logic to allow streaming if `userResHeaderDecorator` accepts a single arguments (`headers`) instead of the full request and response objects.